### PR TITLE
Add support for additional rules and other QoL updates

### DIFF
--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting } from 'obsidian';
+import { App, PluginSettingTab, Setting, TextComponent } from 'obsidian';
 import LanguageToolPlugin from '.';
 
 export interface LanguageToolPluginSettings {
@@ -81,22 +81,29 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName('Endpoint')
 			.setDesc('endpoint that will be used to make requests to')
-			.addText(text =>
-				text
-					.setPlaceholder('Enter endpoint')
-					.setValue(this.plugin.settings.serverUrl)
-					.onChange(async value => {
-						this.plugin.settings.serverUrl = value.replace(/\/v2\/check\/$/, '').replace(/\/$/, '');
-						await this.plugin.saveSettings();
-					}),
-			)
-			.addExtraButton(button => {
-				button
-					.setIcon('reset')
-					.setTooltip('Reset to default')
-					.onClick(async () => {
-						this.plugin.settings.serverUrl = DEFAULT_SETTINGS.serverUrl;
-						await this.plugin.saveSettings();
+			.then(setting => {
+				let input: TextComponent | null = null;
+
+				setting
+					.addText(text => {
+						input = text;
+						text
+							.setPlaceholder('Enter endpoint')
+							.setValue(this.plugin.settings.serverUrl)
+							.onChange(async value => {
+								this.plugin.settings.serverUrl = value.replace(/\/v2\/check\/$/, '').replace(/\/$/, '');
+								await this.plugin.saveSettings();
+							});
+					})
+					.addExtraButton(button => {
+						button
+							.setIcon('reset')
+							.setTooltip('Reset to default')
+							.onClick(async () => {
+								this.plugin.settings.serverUrl = DEFAULT_SETTINGS.serverUrl;
+								input?.setValue(DEFAULT_SETTINGS.serverUrl);
+								await this.plugin.saveSettings();
+							});
 					});
 			});
 		new Setting(containerEl)

--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -7,11 +7,53 @@ export interface LanguageToolPluginSettings {
 	apikey?: string;
 	username?: string;
 	staticLanguage?: string;
+
+	pickyMode: boolean;
+	ruleCasing: boolean;
+	ruleColloquialisms: boolean;
+	ruleCompounding: boolean;
+	ruleConfusedWords: boolean;
+	ruleFalseFriends: boolean;
+	ruleGenderNeutrality: boolean;
+	ruleGrammar: boolean;
+	ruleMisc: boolean;
+	rulePlainEnglish: boolean;
+	rulePunctuation: boolean;
+	ruleRedundancy: boolean;
+	ruleRegionalisms: boolean;
+	ruleRepetitions: boolean;
+	ruleSemantics: boolean;
+	ruleStyle: boolean;
+	ruleTypography: boolean;
+	ruleTypos: boolean;
+
+	ruleOtherCategories?: string;
+	ruleOtherRules?: string;
+	ruleOtherDisabledRules?: string;
 }
 
 export const DEFAULT_SETTINGS: LanguageToolPluginSettings = {
-	serverUrl: 'https://api.languagetool.org/v2/check',
+	serverUrl: 'https://api.languagetool.org',
 	glassBg: false,
+
+	pickyMode: false,
+	ruleGrammar: true,
+	ruleGenderNeutrality: true,
+	ruleColloquialisms: true,
+	ruleStyle: true,
+	ruleRegionalisms: true,
+	ruleCasing: true,
+	ruleCompounding: true,
+	ruleConfusedWords: true,
+	ruleFalseFriends: true,
+	ruleMisc: true,
+	rulePlainEnglish: true,
+	ruleRedundancy: true,
+	ruleRepetitions: true,
+	ruleSemantics: true,
+	rulePunctuation: true,
+	ruleTypos: true,
+	ruleTypography: true,
 };
 
 export class LanguageToolSettingsTab extends PluginSettingTab {
@@ -24,7 +66,7 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 
 	public async requestLanguages() {
 		if (this.languages) return this.languages;
-		const languages = await fetch('https://api.languagetoolplus.com/v2/languages').then(res => res.json());
+		const languages = await fetch(`${this.plugin.settings.serverUrl}/v2/languages`).then(res => res.json());
 		this.languages = languages;
 		return this.languages;
 	}
@@ -44,10 +86,19 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 					.setPlaceholder('Enter endpoint')
 					.setValue(this.plugin.settings.serverUrl)
 					.onChange(async value => {
-						this.plugin.settings.serverUrl = value;
+						this.plugin.settings.serverUrl = value.replace(/\/v2\/check\/$/, '').replace(/\/$/, '');
 						await this.plugin.saveSettings();
 					}),
-			);
+			)
+			.addExtraButton(button => {
+				button
+					.setIcon('reset')
+					.setTooltip('Reset to default')
+					.onClick(async () => {
+						this.plugin.settings.serverUrl = DEFAULT_SETTINGS.serverUrl;
+						await this.plugin.saveSettings();
+					});
+			});
 		new Setting(containerEl)
 			.setName('Glass Background')
 			.setDesc('use the secondary background color of the theme or a glass background')
@@ -74,6 +125,252 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 						});
 					})
 					.catch(console.error);
+			});
+
+		containerEl.createEl('h3', { text: 'Rule Categories' });
+
+		new Setting(containerEl)
+			.setName('Picky Mode')
+			.setDesc(
+				'Provides more style and tonality suggestions, detects long or complex sentences, recognizes colloquialism and redundancies, proactively suggests synonyms for commonly overused words',
+			)
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.pickyMode).onChange(async value => {
+					this.plugin.settings.pickyMode = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Casing')
+			.setDesc('Rules about detecting uppercase words where lowercase is required and vice versa')
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleCasing).onChange(async value => {
+					this.plugin.settings.ruleCasing = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Colloquialisms')
+			.setDesc('Colloquial style')
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleColloquialisms).onChange(async value => {
+					this.plugin.settings.ruleColloquialisms = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Compounding')
+			.setDesc('Rules about spelling terms as one word or as as separate words')
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleCompounding).onChange(async value => {
+					this.plugin.settings.ruleCompounding = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Confused Words')
+			.setDesc(`Words that are easily confused, like 'there' and 'their' in English.`)
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleConfusedWords).onChange(async value => {
+					this.plugin.settings.ruleConfusedWords = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('False Friends')
+			.setDesc(
+				'False friends: words easily confused by language learners because a similar word exists in their native language',
+			)
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleFalseFriends).onChange(async value => {
+					this.plugin.settings.ruleFalseFriends = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl).setName('Gender Neutrality').addToggle(component => {
+			component.setValue(this.plugin.settings.ruleGenderNeutrality).onChange(async value => {
+				this.plugin.settings.ruleGenderNeutrality = value;
+				await this.plugin.saveSettings();
+			});
+		});
+
+		new Setting(containerEl).setName('Grammar').addToggle(component => {
+			component.setValue(this.plugin.settings.ruleGrammar).onChange(async value => {
+				this.plugin.settings.ruleGrammar = value;
+				await this.plugin.saveSettings();
+			});
+		});
+
+		new Setting(containerEl)
+			.setName('Misc')
+			.setDesc(`Miscellaneous rules that don't fit elsewhere.`)
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleMisc).onChange(async value => {
+					this.plugin.settings.ruleMisc = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl).setName('Plain English').addToggle(component => {
+			component.setValue(this.plugin.settings.rulePlainEnglish).onChange(async value => {
+				this.plugin.settings.rulePlainEnglish = value;
+				await this.plugin.saveSettings();
+			});
+		});
+
+		new Setting(containerEl).setName('Punctuation').addToggle(component => {
+			component.setValue(this.plugin.settings.rulePunctuation).onChange(async value => {
+				this.plugin.settings.rulePunctuation = value;
+				await this.plugin.saveSettings();
+			});
+		});
+
+		new Setting(containerEl).setName('Redundancy').addToggle(component => {
+			component.setValue(this.plugin.settings.ruleRedundancy).onChange(async value => {
+				this.plugin.settings.ruleRedundancy = value;
+				await this.plugin.saveSettings();
+			});
+		});
+
+		new Setting(containerEl)
+			.setName('Regionalisms')
+			.setDesc(`Regionalisms: words used only in another language variant or used with different meanings.`)
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleRegionalisms).onChange(async value => {
+					this.plugin.settings.ruleRegionalisms = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl).setName('Repetitions').addToggle(component => {
+			component.setValue(this.plugin.settings.ruleRepetitions).onChange(async value => {
+				this.plugin.settings.ruleRepetitions = value;
+				await this.plugin.saveSettings();
+			});
+		});
+
+		new Setting(containerEl)
+			.setName('Semantics')
+			.setDesc(`Logic, content, and consistency problems.`)
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleSemantics).onChange(async value => {
+					this.plugin.settings.ruleSemantics = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Style')
+			.setDesc(`General style issues not covered by other categories, like overly verbose wording.`)
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleStyle).onChange(async value => {
+					this.plugin.settings.ruleStyle = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Typography')
+			.setDesc(`Problems like incorrectly used dash or quote characters.`)
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleTypography).onChange(async value => {
+					this.plugin.settings.ruleTypography = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Typos')
+			.setDesc(`Spelling issues.`)
+			.addToggle(component => {
+				component.setValue(this.plugin.settings.ruleTypos).onChange(async value => {
+					this.plugin.settings.ruleTypos = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Other rule categories')
+			.setDesc('Enter a comma-separated list of categories')
+			.addText(text =>
+				text
+					.setPlaceholder('Eg. CATEGORY_1,CATEGORY_2')
+					.setValue(this.plugin.settings.ruleOtherCategories || '')
+					.onChange(async value => {
+						this.plugin.settings.ruleOtherCategories = value.replace(/\s+/g, '');
+						await this.plugin.saveSettings();
+					}),
+			)
+			.then(setting => {
+				setting.descEl.createEl('br');
+				setting.descEl.createEl(
+					'a',
+					{
+						text: 'Click here for a list of rules and categories',
+						href: 'https://community.languagetool.org/rule/list',
+					},
+					a => {
+						a.setAttr('target', '_blank');
+					},
+				);
+			});
+
+		new Setting(containerEl)
+			.setName('Enable Specific Rules')
+			.setDesc('Enter a comma-separated list of rules')
+			.addText(text =>
+				text
+					.setPlaceholder('Eg. RULE_1,RULE_2')
+					.setValue(this.plugin.settings.ruleOtherRules || '')
+					.onChange(async value => {
+						this.plugin.settings.ruleOtherRules = value.replace(/\s+/g, '');
+						await this.plugin.saveSettings();
+					}),
+			)
+			.then(setting => {
+				setting.descEl.createEl('br');
+				setting.descEl.createEl(
+					'a',
+					{
+						text: 'Click here for a list of rules and categories',
+						href: 'https://community.languagetool.org/rule/list',
+					},
+					a => {
+						a.setAttr('target', '_blank');
+					},
+				);
+			});
+
+		new Setting(containerEl)
+			.setName('Disable Specific Rules')
+			.setDesc('Enter a comma-separated list of rules')
+			.addText(text =>
+				text
+					.setPlaceholder('Eg. RULE_1,RULE_2')
+					.setValue(this.plugin.settings.ruleOtherDisabledRules || '')
+					.onChange(async value => {
+						this.plugin.settings.ruleOtherDisabledRules = value.replace(/\s+/g, '');
+						await this.plugin.saveSettings();
+					}),
+			)
+			.then(setting => {
+				setting.descEl.createEl('br');
+				setting.descEl.createEl(
+					'a',
+					{
+						text: 'Click here for a list of rules and categories',
+						href: 'https://community.languagetool.org/rule/list',
+					},
+					a => {
+						a.setAttr('target', '_blank');
+					},
+				);
 			});
 	}
 }

--- a/src/Widget.ts
+++ b/src/Widget.ts
@@ -1,4 +1,5 @@
 import EventEmitter from 'events';
+import { getIssueTypeClassName } from './helpers';
 
 export declare interface Widget {
 	on(event: 'click', listener: (name: string) => any): this;
@@ -13,11 +14,14 @@ export class Widget extends EventEmitter {
 		return this.elem;
 	}
 
-	public constructor(args: { title: string; message: string; buttons: string[] }, classToUse: string) {
+	public constructor(
+		args: { title: string; message: string; buttons: string[]; category: string },
+		classToUse: string,
+	) {
 		super();
 		const rootDiv = document.createElement('div');
 		rootDiv.style.zIndex = '99';
-		rootDiv.classList.add(classToUse);
+		rootDiv.classList.add(classToUse, getIssueTypeClassName(args.category));
 		const titleSpan = document.createElement('span');
 		titleSpan.classList.add('lt-title');
 		titleSpan.innerText = args.title;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,13 +6,13 @@ export function getIssueTypeClassName(categoryId: string) {
 		case 'COLLOQUIALISMS':
 		case 'REDUNDANCY':
 		case 'STYLE':
-			return 'lt-underline lt-style';
+			return 'lt-style';
 		case 'PUNCTUATION':
 		case 'TYPOS':
-			return 'lt-underline lt-major';
+			return 'lt-major';
 	}
 
-	return 'lt-underline lt-minor';
+	return 'lt-minor';
 }
 
 // Construct a list of enabled / disabled rules

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,113 @@
+import { LanguageToolPluginSettings } from './SettingsTab';
+
+// Assign a CSS class based on a rule's category ID
+export function getIssueTypeClassName(categoryId: string) {
+	switch (categoryId) {
+		case 'COLLOQUIALISMS':
+		case 'REDUNDANCY':
+		case 'STYLE':
+			return 'lt-underline lt-style';
+		case 'PUNCTUATION':
+		case 'TYPOS':
+			return 'lt-underline lt-major';
+	}
+
+	return 'lt-underline lt-minor';
+}
+
+// Construct a list of enabled / disabled rules
+export function getRuleCategories(settings: LanguageToolPluginSettings) {
+	const enabledCategories: string[] = settings.ruleOtherCategories ? settings.ruleOtherCategories.split(',') : [];
+	const disabledCategories: string[] = [];
+
+	if (settings.ruleCasing) {
+		enabledCategories.push('CASING');
+	} else {
+		disabledCategories.push('CASING');
+	}
+	if (settings.ruleColloquialisms) {
+		enabledCategories.push('COLLOCATIONS');
+	} else {
+		disabledCategories.push('COLLOCATIONS');
+	}
+	if (settings.ruleCompounding) {
+		enabledCategories.push('COMPOUNDING');
+	} else {
+		disabledCategories.push('COMPOUNDING');
+	}
+	if (settings.ruleConfusedWords) {
+		enabledCategories.push('CONFUSED_WORDS');
+	} else {
+		disabledCategories.push('CONFUSED_WORDS');
+	}
+	if (settings.ruleFalseFriends) {
+		enabledCategories.push('FALSE_FRIENDS');
+	} else {
+		disabledCategories.push('FALSE_FRIENDS');
+	}
+	if (settings.ruleGenderNeutrality) {
+		enabledCategories.push('GENDER_NEUTRALITY');
+	} else {
+		disabledCategories.push('GENDER_NEUTRALITY');
+	}
+	if (settings.ruleGrammar) {
+		enabledCategories.push('GRAMMAR');
+	} else {
+		disabledCategories.push('GRAMMAR');
+	}
+	if (settings.ruleMisc) {
+		enabledCategories.push('MISC');
+	} else {
+		disabledCategories.push('MISC');
+	}
+	if (settings.rulePlainEnglish) {
+		enabledCategories.push('PLAIN_ENGLISH');
+	} else {
+		disabledCategories.push('PLAIN_ENGLISH');
+	}
+	if (settings.rulePunctuation) {
+		enabledCategories.push('PUNCTUATION');
+	} else {
+		disabledCategories.push('PUNCTUATION');
+	}
+	if (settings.ruleRedundancy) {
+		enabledCategories.push('REDUNDANCY');
+	} else {
+		disabledCategories.push('REDUNDANCY');
+	}
+	if (settings.ruleRegionalisms) {
+		enabledCategories.push('REGIONALISMS');
+	} else {
+		disabledCategories.push('REGIONALISMS');
+	}
+	if (settings.ruleRepetitions) {
+		enabledCategories.push('REPETITIONS');
+	} else {
+		disabledCategories.push('REPETITIONS');
+	}
+	if (settings.ruleSemantics) {
+		enabledCategories.push('SEMANTICS');
+	} else {
+		disabledCategories.push('SEMANTICS');
+	}
+	if (settings.ruleStyle) {
+		enabledCategories.push('STYLE');
+	} else {
+		disabledCategories.push('STYLE');
+	}
+	if (settings.ruleTypography) {
+		enabledCategories.push('TYPOGRAPHY');
+	} else {
+		disabledCategories.push('TYPOGRAPHY');
+	}
+	if (settings.ruleTypos) {
+		enabledCategories.push('TYPOS');
+	} else {
+		disabledCategories.push('TYPOS');
+	}
+
+	return {
+		enabledCategories,
+		disabledCategories,
+	};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,13 @@ export default class LanguageToolPlugin extends Plugin {
 		maxSize: 10,
 	});
 
+	public onunload() {
+		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+		if (!view || this.markerMap.size === 0) return;
+		const cm = view.sourceMode.cmEditor;
+		this.clearMarks(cm);
+	}
+
 	public async onload() {
 		await this.loadSettings();
 		this.addSettingTab(new LanguageToolSettingsTab(this.app, this));

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export default class LanguageToolPlugin extends Plugin {
 					message: match.message,
 					title: match.shortMessage,
 					buttons: match.replacements!.slice(0, 3).map(v => v.value),
+					category: match.rule.category.id,
 				},
 				this.settings.glassBg ? 'lt-predictions-container-glass' : 'lt-predictions-container',
 			).on('click', text => {
@@ -208,7 +209,7 @@ export default class LanguageToolPlugin extends Plugin {
 				{ ch: line.remaining, line: line.line },
 				{ ch: line.remaining + match.length, line: line.line },
 				{
-					className: getIssueTypeClassName(match.rule.category.id),
+					className: `lt-underline ${getIssueTypeClassName(match.rule.category.id)}`,
 					clearOnEnter: false,
 				},
 			);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as Remark from 'annotatedtext-remark';
 import CodeMirror from 'codemirror';
 import { MarkdownView, Notice, Plugin } from 'obsidian';
 import QuickLRU from 'quick-lru';
+import { getIssueTypeClassName, getRuleCategories } from './helpers';
 import { LanguageToolApi, MatchesEntity } from './LanguageToolTypings';
 import { DEFAULT_SETTINGS, LanguageToolPluginSettings, LanguageToolSettingsTab } from './SettingsTab';
 import { Widget } from './Widget';
@@ -20,45 +21,58 @@ export default class LanguageToolPlugin extends Plugin {
 		await this.loadSettings();
 		this.addSettingTab(new LanguageToolSettingsTab(this.app, this));
 
-		this.registerDomEvent(document, 'click', e => {
-			if (!this.openWidget) {
-				const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-				if (!view) return;
-				const editor = view.sourceMode.cmEditor;
+		// Using the click event won't trigger the widget consistently, so use pointerup instead
+		this.registerDomEvent(document, 'pointerup', e => {
+			const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+			if (!view) return;
 
-				// return if element is not in the editor
-				if (!editor.getWrapperElement().contains(e.target as ChildNode)) return;
-
-				const lineCh = editor.coordsChar({ left: e.clientX, top: e.clientY });
-				const markers = editor.findMarksAt(lineCh);
-				if (markers.length < 1) return;
-				// assume there is only a single marker
-				const [marker] = markers;
-				const match = this.markerMap.get(marker);
-				if (!match) return;
-
-				this.openWidget = new Widget(
-					{
-						message: match.message,
-						title: match.shortMessage,
-						buttons: match.replacements!.slice(0, 3).map(v => v.value),
-					},
-					this.settings.glassBg ? 'lt-predictions-container-glass' : 'lt-predictions-container',
-				).on('click', text => {
-					const { from, to } = marker.find();
-					editor.replaceRange(text, from, to);
-					marker.clear();
-					this.openWidget?.destroy();
-					this.openWidget = undefined;
-				});
-				editor.addWidget(lineCh, this.openWidget.element, true);
+			if (e.target === this.openWidget?.element || this.openWidget?.element.contains(e.target as ChildNode)) {
 				return;
 			}
-			if (e.target === this.openWidget.element || this.openWidget.element.contains(e.target as ChildNode)) return;
 
-			this.openWidget.destroy();
-			this.openWidget = undefined;
+			// Destroy any open widgets if we're not clicking in one
+			if (this.openWidget) {
+				this.openWidget.destroy();
+				this.openWidget = undefined;
+			}
+
+			// Don't open if we have no marks or aren't clicking on a mark
+			if (this.markerMap.size === 0 || (e.target instanceof HTMLElement && !e.target.hasClass('lt-underline'))) {
+				return;
+			}
+
+			const editor = view.sourceMode.cmEditor;
+
+			// return if element is not in the editor
+			if (!editor.getWrapperElement().contains(e.target as ChildNode)) return;
+
+			const lineCh = editor.coordsChar({ left: e.clientX, top: e.clientY });
+			const markers = editor.findMarksAt(lineCh);
+
+			if (markers.length === 0) return;
+
+			// assume there is only a single marker
+			const marker = markers[0];
+			const match = this.markerMap.get(marker);
+			if (!match) return;
+
+			this.openWidget = new Widget(
+				{
+					message: match.message,
+					title: match.shortMessage,
+					buttons: match.replacements!.slice(0, 3).map(v => v.value),
+				},
+				this.settings.glassBg ? 'lt-predictions-container-glass' : 'lt-predictions-container',
+			).on('click', text => {
+				const { from, to } = marker.find() as CodeMirror.MarkerRange;
+				editor.replaceRange(text, from, to);
+				marker.clear();
+				this.openWidget?.destroy();
+				this.openWidget = undefined;
+			});
+			editor.addWidget(lineCh, this.openWidget.element, true);
 		});
+
 		this.addCommand({
 			id: 'ltcheck-text',
 			name: 'Check Text',
@@ -71,6 +85,19 @@ export default class LanguageToolPlugin extends Plugin {
 				this.runDetection(cm);
 			},
 		});
+
+		this.addCommand({
+			id: 'ltclear',
+			name: 'Clear Suggestions',
+			checkCallback: checking => {
+				const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+				if (checking) return Boolean(view) || this.markerMap.size > 0;
+				if (!view) return;
+				const cm = view!.sourceMode.cmEditor;
+				// eslint-disable-next-line @typescript-eslint/no-floating-promises
+				this.clearMarks(cm);
+			},
+		});
 	}
 
 	private async getDetectionResult(text: string): Promise<LanguageToolApi> {
@@ -78,10 +105,32 @@ export default class LanguageToolPlugin extends Plugin {
 		if (this.hashLru.has(hash)) {
 			return this.hashLru.get(hash)!;
 		}
+
+		const { enabledCategories, disabledCategories } = getRuleCategories(this.settings);
+
 		const params: { [key: string]: string } = {
 			data: text,
 			language: 'auto',
+			enabledOnly: 'true',
+			level: this.settings.pickyMode ? 'picky' : 'default',
 		};
+
+		if (enabledCategories.length) {
+			params.enabledCategories = enabledCategories.join(',');
+		}
+
+		if (disabledCategories.length) {
+			params.disabledCategories = disabledCategories.join(',');
+		}
+
+		if (this.settings.ruleOtherRules) {
+			params.enabledRules = this.settings.ruleOtherRules;
+		}
+
+		if (this.settings.ruleOtherDisabledRules) {
+			params.disabledRules = this.settings.ruleOtherDisabledRules;
+		}
+
 		if (
 			this.settings.apikey &&
 			this.settings.username &&
@@ -98,7 +147,8 @@ export default class LanguageToolPlugin extends Plugin {
 		) {
 			params.language = this.settings.staticLanguage;
 		}
-		const res = await fetch(this.settings.serverUrl, {
+
+		const res = await fetch(`${this.settings.serverUrl}/v2/check`, {
 			method: 'POST',
 			body: Object.keys(params)
 				.map(key => {
@@ -110,13 +160,21 @@ export default class LanguageToolPlugin extends Plugin {
 				Accept: 'application/json',
 			},
 		});
+
 		if (!res.ok) {
 			new Notice(`request to LanguageTool failed\n${res.statusText}`, 5000);
 			throw new Error(`unexpected status ${res.status}, see network tab`);
 		}
+
 		const body: LanguageToolApi = await res.json();
 		this.hashLru.set(hash, body);
+
 		return body;
+	}
+
+	private clearMarks(editor: CodeMirror.Editor) {
+		editor.getAllMarks().forEach(mark => mark.clear());
+		this.markerMap.clear();
 	}
 
 	private async runDetection(editor: CodeMirror.Editor) {
@@ -132,9 +190,10 @@ export default class LanguageToolPlugin extends Plugin {
 
 		const parsedText = Remark.build(text, Remark.defaults);
 		const res = await this.getDetectionResult(JSON.stringify(parsedText));
-		editor.getAllMarks().forEach(mark => mark.clear());
-		this.markerMap.clear();
+
+		this.clearMarks(editor);
 		this.statusBarText.setText(res.language.name);
+
 		for (const match of res.matches!) {
 			const line = this.getLine(fullText, match.offset + offset);
 
@@ -142,7 +201,7 @@ export default class LanguageToolPlugin extends Plugin {
 				{ ch: line.remaining, line: line.line },
 				{ ch: line.remaining + match.length, line: line.line },
 				{
-					className: match.rule.issueType === 'typographical' ? 'lt-minor' : 'lt-major',
+					className: getIssueTypeClassName(match.rule.category.id),
 					clearOnEnter: false,
 				},
 			);

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,6 @@ export default class LanguageToolPlugin extends Plugin {
 		const params: { [key: string]: string } = {
 			data: text,
 			language: 'auto',
-			enabledOnly: 'true',
 			level: this.settings.pickyMode ? 'picky' : 'default',
 		};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,7 @@ export default class LanguageToolPlugin extends Plugin {
 		const params: { [key: string]: string } = {
 			data: text,
 			language: 'auto',
+			enabledOnly: 'true',
 			level: this.settings.pickyMode ? 'picky' : 'default',
 		};
 

--- a/styles.css
+++ b/styles.css
@@ -1,16 +1,30 @@
+.lt-underline {
+  cursor: pointer;
+  transition: background-color 100ms ease-out;
+}
+
 .lt-minor {
-  text-decoration: underline;
-  text-decoration-color: #ff0;
-  text-decoration-thickness: 5;
-  background-color: rgba(255, 255, 0, 0.15);
+  box-shadow: inset 0 -2px #e9b35f;
 }
 
 .lt-major {
-  text-decoration: underline;
-  text-decoration-color: #f00;
-  text-decoration-thickness: 5;
-  cursor: pointer;
-  background-color: rgba(255, 0, 0, 0.15);
+  box-shadow: inset 0 -2px #da615c;
+}
+
+.lt-style {
+  box-shadow: inset 0 -2px #8981f3;
+}
+
+.lt-minor:hover {
+  background-color: #e9b35f21;
+}
+
+.lt-major:hover {
+  background-color: #da615c21;
+}
+
+.lt-style:hover {
+  background-color: #8981f321;
 }
 
 .lt-predictions-container-glass {
@@ -26,7 +40,6 @@
   max-width: 24rem;
   padding: 1rem;
   background: hsla(0, 0%, 100%, 0.25);
-  z-index: 1;
   backdrop-filter: blur(12px);
   border-radius: 0.5rem;
   border: 1px solid hsla(0, 0%, 100%, 0.25);

--- a/styles.css
+++ b/styles.css
@@ -3,27 +3,27 @@
   transition: background-color 100ms ease-out;
 }
 
-.lt-minor {
+.lt-underline.lt-minor {
   box-shadow: inset 0 -2px #e9b35f;
 }
 
-.lt-major {
+.lt-underline.lt-major {
   box-shadow: inset 0 -2px #da615c;
 }
 
-.lt-style {
+.lt-underline.lt-style {
   box-shadow: inset 0 -2px #8981f3;
 }
 
-.lt-minor:hover {
+.lt-underline.lt-minor:hover {
   background-color: #e9b35f21;
 }
 
-.lt-major:hover {
+.lt-underline.lt-major:hover {
   background-color: #da615c21;
 }
 
-.lt-style:hover {
+.lt-underline.lt-style:hover {
   background-color: #8981f321;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,10 +278,10 @@
     remark "^13.0.0"
     unist-util-find-all-after "^3.0.2"
 
-"@types/codemirror@0.0.98":
-  version "0.0.98"
-  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.98.tgz#b35c7a4ab1fc1684b08a4e3eb65240020556ebfb"
-  integrity sha512-cbty5LPayy2vNSeuUdjNA9tggG+go5vAxmnLDRWpiZI5a+RDBi9dlozy4/jW/7P/gletbBWbQREEa7A81YxstA==
+"@types/codemirror@0.0.108":
+  version "0.0.108"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.108.tgz#e640422b666bf49251b384c390cdeb2362585bde"
+  integrity sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==
   dependencies:
     "@types/tern" "*"
 
@@ -2027,6 +2027,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+moment@2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -2135,10 +2140,11 @@ object.values@^1.1.3:
     has "^1.0.3"
 
 "obsidian@https://github.com/obsidianmd/obsidian-api/tarball/master":
-  version "0.11.7"
-  resolved "https://github.com/obsidianmd/obsidian-api/tarball/master#28c00facf01a4f832d3e4ffb879139c7a627aa52"
+  version "0.12.2"
+  resolved "https://github.com/obsidianmd/obsidian-api/tarball/master#ba2c41178aaf446b0a1d4a8b690660f9cf90130e"
   dependencies:
-    "@types/codemirror" "0.0.98"
+    "@types/codemirror" "0.0.108"
+    moment "2.29.1"
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
Hey @Clemens-E, thanks for the great plugin!

I apologies for the large PR, but there were a few things that were making this plugin difficult to use, and I thought I'd knock them out all at once.

Here's what I did:

1. Added settings for toggling rule categories, and enabling /  disabling specific rules (re: #6)
2. Added support for "picky mode"
2. Added additional styling to match the language tool app. Specifically, I added a "style" underline
3. Updated the underlines to more closely match language tool (hope this is ok, let me know if you'd like me to revert these changes)
4. Fixed some issues around the widget not opening when clicking on marks, and not disappearing when clicking elsewhere
5. Enhanced support for a local languagetool server so that this plugin works offline when a local server is running
6. Added a command to clear marks

<img width="1064" alt="Screen Shot 2021-05-16 at 11 26 21 AM" src="https://user-images.githubusercontent.com/2694747/118408240-8d015d00-b639-11eb-98e1-adc85f8c46cf.png">
