### PR TITLE
Set `enabledOnly` to 'false'; for real this time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export default class LanguageToolPlugin extends Plugin {
 		const params: { [key: string]: string } = {
 			data: text,
 			language: 'auto',
-			enabledOnly: 'true',
+			enabledOnly: 'false',
 			level: this.settings.pickyMode ? 'picky' : 'default',
 		};
 


### PR DESCRIPTION
Apologies for the confusion. Things do indeed work as they should when `enabledOnly` is set to `false`. I've tested manually enabling / disabling categories and rules, and it all seems to work properly now.