### PR TITLE
Remove tooltip from rollup externals

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,6 @@ export default {
         '@codemirror/state',
         '@codemirror/stream-parser',
         '@codemirror/text',
-        '@codemirror/tooltip',
         '@codemirror/view',
     ],
     plugins: [


### PR DESCRIPTION
The tooltip plugin isn't loaded by obsidian and thus we need to roll it up when building main.js otherwise the plugin cannot be loaded.

This resolves #43 