### PR TITLE
feat: Add Customizable AutoCheck Debounce Slider

### DIFF
--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -1,9 +1,20 @@
-import { App, DropdownComponent, Modal, Notice, PluginSettingTab, Setting, TextComponent } from 'obsidian';
+import { App, DropdownComponent, Modal, Notice, PluginSettingTab, Setting, SliderComponent, TextComponent } from 'obsidian';
 import LanguageToolPlugin from '.';
 import { logs } from './api';
 
+const MinuteInSeconds = 60;
+const SecondToMillisecondConversion = 1000;
+const StandardMaxRequestsPerMinute = 20;
+const PremiumMaxRequestsPerMinute = 80;
+
+const MaxAutoCheckDelay = 3000;
+const AutoCheckDelayStep = 200;
+const MinStandardAutoCheckDelay = MinuteInSeconds / StandardMaxRequestsPerMinute * SecondToMillisecondConversion;
+const MinPremiumAutoCheckDelay = MinuteInSeconds / PremiumMaxRequestsPerMinute * SecondToMillisecondConversion;
+
 export interface LanguageToolPluginSettings {
 	shouldAutoCheck: boolean;
+	autoCheckDelay: number;
 
 	serverUrl: string;
 	urlMode: 'standard' | 'premium' | 'custom';
@@ -30,6 +41,7 @@ export const DEFAULT_SETTINGS: LanguageToolPluginSettings = {
 
 	glassBg: false,
 	shouldAutoCheck: false,
+	autoCheckDelay: MinStandardAutoCheckDelay,
 
 	pickyMode: false,
 };
@@ -42,12 +54,33 @@ function getServerUrl(value: string) {
 		: '';
 }
 
+function getMinAllowedAutoCheckDelay(value: string) {
+	return value === 'standard'
+		? MinStandardAutoCheckDelay
+		: value === 'premium'
+		? MinPremiumAutoCheckDelay
+		: 0;
+}
+
 export class LanguageToolSettingsTab extends PluginSettingTab {
 	private readonly plugin: LanguageToolPlugin;
 	private languages: { name: string; code: string; longCode: string }[];
 	public constructor(app: App, plugin: LanguageToolPlugin) {
 		super(app, plugin);
 		this.plugin = plugin;
+	}
+
+	configureAutoCheckDelaySlider(delaySlider: SliderComponent | null, value: string)
+	{
+		const minAllowedAutoCheckDelay = getMinAllowedAutoCheckDelay(value)
+
+		if(this.plugin.settings.autoCheckDelay < minAllowedAutoCheckDelay)
+		{
+			this.plugin.settings.autoCheckDelay = MinStandardAutoCheckDelay;
+		}
+
+		delaySlider?.setDisabled(value === 'standard');
+		delaySlider?.setLimits(minAllowedAutoCheckDelay, MaxAutoCheckDelay, AutoCheckDelayStep);
 	}
 
 	public async requestLanguages() {
@@ -60,6 +93,7 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 	public display(): void {
 		const { containerEl } = this;
 		let urlDropdown: DropdownComponent | null = null;
+		let autoCheckDelaySlider: SliderComponent | null = null;
 		containerEl.empty();
 		containerEl.createEl('h2', { text: 'Settings for LanguageTool' });
 		const copyButton = containerEl.createEl('button', { text: 'Copy failed Request Logs' });
@@ -88,7 +122,10 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 							this.plugin.settings.urlMode = value as 'standard' | 'premium' | 'custom';
 							this.plugin.settings.serverUrl = getServerUrl(value);
 							input?.setValue(this.plugin.settings.serverUrl);
-							input?.setDisabled(value !== 'custom');
+							input?.setDisabled((value !== 'custom'));
+							
+							this.configureAutoCheckDelaySlider(autoCheckDelaySlider, value);
+
 							await this.plugin.saveSettings();
 						});
 				});
@@ -195,6 +232,21 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 					this.plugin.settings.shouldAutoCheck = value;
 					await this.plugin.saveSettings();
 				});
+			});
+		new Setting(containerEl)
+			.setName('AutoCheck Delay (ms)')
+			.setDesc('Length of time to wait for AutoCheck after last key press')
+			.addSlider(component => {
+				autoCheckDelaySlider = component;
+				
+				this.configureAutoCheckDelaySlider(autoCheckDelaySlider, urlDropdown?.getValue());
+
+				component.setValue(this.plugin.settings.autoCheckDelay).onChange(async value => {
+					this.plugin.settings.autoCheckDelay = value;
+					await this.plugin.saveSettings();
+				});
+				
+				component.setDynamicTooltip();
 			});
 		new Setting(containerEl)
 			.setName('Glass Background')

--- a/src/cm6/buildAutoCheckHandler.ts
+++ b/src/cm6/buildAutoCheckHandler.ts
@@ -27,8 +27,7 @@ export function buildAutoCheckHandler(plugin: LanguageToolPlugin) {
 			plugin.runDetection(view, markdownView as MarkdownView, startLine.from, endLine.to).catch(e => {
 				console.error(e);
 			});
-			// The API has a rate limit of 1 request every 3 seconds
-		}, 3000);
+		}, plugin.settings.autoCheckDelay);
 
 		return false;
 	});


### PR DESCRIPTION
Replaced static 3000ms AutoCheck delay with a slider in the settings tab 
Standard LT API has 3000ms min AutoCheck delay cap and disables slider 
Premium LT API has 750ms min delay cap with slider enabled 
Custom LT API has 0ms min delay cap

[Kooha-2023-01-22-01-43-02.webm](https://user-images.githubusercontent.com/26135914/213897025-d8a6d854-afac-4788-8ac9-20bcd3f6fb6c.webm)

I have added a slider for the AutoCheck debounce. I refer to it as `autoCheckDelay` in the code. I have disabled the slider in standard mode and set it to 3000ms. With premium I use the limit of 80 requests per minute that they suggest, so 750ms as the lower limit and a max of 3000ms on the slider. With custom I allow the user to set anything from 0 - 3000ms. 

I added consts to the top to make it easy to configure these values if they need to be changed in the future.

I chose a slider over a number field because I felt that it was more user friendly. Hopefully 200ms is a good step for the slider.

Closes: https://github.com/Clemens-E/obsidian-languagetool-plugin/issues/89

Quick Note: I didn't change the version number if that's an issue.