### PR TITLE
fix: prevent language settings causing api errors

### DIFF
--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -206,6 +206,11 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 				});
 			});
 		let staticLanguageComponent: DropdownComponent | null;
+		let englishVarietyDropdown: DropdownComponent | null;
+		let germanVarietyDropdown: DropdownComponent | null;
+		let portugueseVarietyDropdown: DropdownComponent | null;
+		let catalanVarietyDropdown: DropdownComponent | null;
+
 		new Setting(containerEl)
 			.setName('Static Language')
 			.setDesc(
@@ -220,6 +225,16 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 						component.setValue(this.plugin.settings.staticLanguage ?? 'auto');
 						component.onChange(async value => {
 							this.plugin.settings.staticLanguage = value;
+							if (value !== 'auto') {
+								this.plugin.settings.englishVeriety = undefined;
+								englishVarietyDropdown?.setValue('default');
+								this.plugin.settings.germanVeriety = undefined;
+								germanVarietyDropdown?.setValue('default');
+								this.plugin.settings.portugueseVeriety = undefined;
+								portugueseVarietyDropdown?.setValue('default');
+								this.plugin.settings.catalanVeriety = undefined;
+								catalanVarietyDropdown?.setValue('default');
+							}
 							await this.plugin.saveSettings();
 						});
 					})
@@ -231,6 +246,7 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 		containerEl.createEl('p', { text: 'Some languages have varieties depending on the country they are spoken in.' });
 
 		new Setting(containerEl).setName('Interpret English as').addDropdown(component => {
+			englishVarietyDropdown = component;
 			component
 				.addOptions({
 					default: '---',
@@ -255,6 +271,7 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 		});
 
 		new Setting(containerEl).setName('Interpret German as').addDropdown(component => {
+			germanVarietyDropdown = component;
 			component
 				.addOptions({
 					default: '---',
@@ -276,6 +293,7 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 		});
 
 		new Setting(containerEl).setName('Interpret Portuguese as').addDropdown(component => {
+			portugueseVarietyDropdown = component;
 			component
 				.addOptions({
 					default: '---',
@@ -298,6 +316,7 @@ export class LanguageToolSettingsTab extends PluginSettingTab {
 		});
 
 		new Setting(containerEl).setName('Interpret Catalan as').addDropdown(component => {
+			catalanVarietyDropdown = component;
 			component
 				.addOptions({
 					default: '---',


### PR DESCRIPTION
Fixes a small issue I encountered, when changing the language varieties and then changing the static language option. This causes api errors since language must be set to 'auto' in order to change the preferred language. 

To fix this issue I just modified the static language setting to mimic the behaviour of the language varieties (when the varieties are modified to anything else besides default, the static language setting is set to auto). So in the same way, when the static language setting is changed it resets all the language varieties to undefined.

Modified only src/SettingsTab.ts.