### PR TITLE
Notifications about network issues should only be displayed once

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -100,7 +100,7 @@ export async function getDetectionResult(
 		});
 	} catch (e) {
 		const status = 'request-failed';
-		if (lastStatus !== status) {
+		if (lastStatus !== status || !settings.shouldAutoCheck) {
 			new Notice(`Request to LanguageTool server failed. Please check your connection and LanguageTool server URL`, 0);
 			lastStatus = status;
 		}
@@ -110,7 +110,7 @@ export async function getDetectionResult(
 	if (!res.ok) {
 		const status = 'request-not-ok';
 		await pushLogs(res, settings);
-		if (lastStatus !== status) {
+		if (lastStatus !== status || !settings.shouldAutoCheck) {
 			new Notice(`Request to LanguageTool failed\n${res.statusText}Check Plugin Settings for Logs`, 0);
 			lastStatus = status;
 		}
@@ -122,7 +122,7 @@ export async function getDetectionResult(
 		body = await res.json();
 	} catch (e) {
 		const status = 'json-parse-error';
-		if (lastStatus !== status) {
+		if (lastStatus !== status || !settings.shouldAutoCheck) {
 			new Notice(`Error processing response from LanguageTool server`, 0);
 			lastStatus = status;
 		}
@@ -130,7 +130,7 @@ export async function getDetectionResult(
 	}
 
 	const status = 'ok';
-	if (lastStatus !== status) {
+	if (lastStatus !== status || !settings.shouldAutoCheck) {
 		new Notice(`LanguageTool detection restored`, 5000);
 		lastStatus = status;
 	}

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,7 @@ import { LanguageToolPluginSettings } from './SettingsTab';
 
 export const logs: string[] = [];
 
-let lastStatus: string = "ok";
+let lastStatus: 'ok' | 'request-failed' | 'request-not-ok' | 'json-parse-error' = 'ok';
 
 export async function getDetectionResult(
 	text: string,

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,6 +6,8 @@ import { LanguageToolPluginSettings } from './SettingsTab';
 
 export const logs: string[] = [];
 
+let lastStatus: string = "ok";
+
 export async function getDetectionResult(
 	text: string,
 	getSettings: () => LanguageToolPluginSettings,
@@ -97,13 +99,21 @@ export async function getDetectionResult(
 			},
 		});
 	} catch (e) {
-		new Notice(`Request to LanguageTool server failed. Please check your connection and LanguageTool server URL`, 5000);
+		const status = 'request-failed';
+		if (lastStatus !== status) {
+			new Notice(`Request to LanguageTool server failed. Please check your connection and LanguageTool server URL`, 0);
+			lastStatus = status;
+		}
 		return Promise.reject(e);
 	}
 
 	if (!res.ok) {
+		const status = 'request-not-ok';
 		await pushLogs(res, settings);
-		new Notice(`Request to LanguageTool failed\n${res.statusText}Check Plugin Settings for Logs`, 5000);
+		if (lastStatus !== status) {
+			new Notice(`Request to LanguageTool failed\n${res.statusText}Check Plugin Settings for Logs`, 0);
+			lastStatus = status;
+		}
 		return Promise.reject(new Error(`unexpected status ${res.status}, see network tab`));
 	}
 
@@ -111,8 +121,18 @@ export async function getDetectionResult(
 	try {
 		body = await res.json();
 	} catch (e) {
-		new Notice(`Error processing response from LanguageTool server`, 5000);
+		const status = 'json-parse-error';
+		if (lastStatus !== status) {
+			new Notice(`Error processing response from LanguageTool server`, 0);
+			lastStatus = status;
+		}
 		return Promise.reject(e);
+	}
+
+	const status = 'ok';
+	if (lastStatus !== status) {
+		new Notice(`LanguageTool detection restored`, 5000);
+		lastStatus = status;
 	}
 
 	return body;


### PR DESCRIPTION
At present, there is a failure, a notification will be displayed every time document checking happens. If auto-checking is on, it will appear over and over, disappearing and reappearing every few seconds.

This PR makes it so that repeat notifications are suppressed when auto-checking.

Sorry the video is so long, but it shows both the present behavior and new behavior.


https://github.com/Clemens-E/obsidian-languagetool-plugin/assets/1031876/b89a872c-ed28-48f8-9490-9a8338d8491e

