### PR TITLE
Add basic auth support

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -95,19 +95,27 @@ export async function getDetectionResult(
 		params.motherTongue = settings.motherTongue;
 	}
 
+	let url = `${settings.serverUrl}/v2/check`;
+	let headers: HeadersInit = {
+		'Content-Type': 'application/x-www-form-urlencoded',
+		Accept: 'application/json',
+	};
+
+	if (settings.urlMode === 'custom' && settings.customUrl && settings.authHeader) {
+		url = `${settings.customUrl}/v2/check`;
+		headers.Authorization = settings.authHeader;
+	}
+
 	let res: Response;
 	try {
-		res = await fetch(`${settings.serverUrl}/v2/check`, {
+		res = await fetch(url, {
 			method: 'POST',
 			body: Object.keys(params)
 				.map(key => {
 					return `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`;
 				})
 				.join('&'),
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-				Accept: 'application/json',
-			},
+			headers: headers,
 		});
 	} catch (e) {
 		const status = 'request-failed';


### PR DESCRIPTION
Add basic auth for reverse proxy using this format: "https://user:pass@url"

---

If someone have reverse proxy (in my case nginx), you need to add this (with `Access-Control-Allow-Origin "*"`): https://stackoverflow.com/a/57499239/11451105