### PR TITLE
Fix auto-check race condition: drop stale responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -345,7 +345,9 @@ export default class LanguageToolPlugin extends Plugin {
 
     this.setStatusBarWorking();
 
-    const selection = editor.state.selection.main;
+    const state = editor.state;
+    const selection = state.selection.main;
+    const currentDoc = state.doc;
 
     let text = view.data;
     let offset = 0;
@@ -359,7 +361,7 @@ export default class LanguageToolPlugin extends Plugin {
     }
 
     if (from !== undefined && to !== undefined) {
-      text = editor.state.sliceDoc(from, to);
+      text = state.sliceDoc(from, to);
       offset = from;
       rangeFrom = from;
       rangeTo = to;
@@ -378,6 +380,14 @@ export default class LanguageToolPlugin extends Plugin {
       } catch (e) {
         this.setStatusBarReady();
         return Promise.reject(e);
+      }
+
+      // Avoid updating the underlines if the document has changed.
+      // As the CodeMirror state is immutable, we can directly compare
+      // the text objects.
+      if (currentDoc !== editor.state.doc) {
+        this.setStatusBarReady();
+        return;
       }
     }
 


### PR DESCRIPTION
## Problem

`runDetection()` in `src/index.ts` has a race window between `await getDetectionResult(...)` and `editor.dispatch({effects})`. While the LT request is in flight, the user can keep editing the document. Match offsets returned by the API are computed against the text we *sent*, so applying them to the *current* document underlines the wrong content.

## Fix

After the request resolves (in the cache-miss branch), compare the live doc text to the `text` snapshot we used for the request. If they differ, return without dispatching — the next auto-check will pick up the new state. The cache-hit path is unaffected: matches there are already correct for the current text by virtue of the hash matching.

```ts
// Race-condition guard: the document may have been edited while the
// request was in flight. ...
const liveText = isRange
  ? editor.state.sliceDoc(rangeFrom, rangeTo)
  : view.data;
if (liveText !== text) {
  this.setStatusBarReady();
  return;
}
```

## Diff

12 lines added in `src/index.ts`. No new files, no dep changes, no behaviour changes outside the race scenario.

## Background

This is a small, targeted fix for the long-standing "underlines may not move correctly when typing" issue. I previously verified the same logic in a sister fork ([wrenger/obsidian-languagetool#56](https://github.com/wrenger/obsidian-languagetool/pull/56)) where it's covered by 8 unit tests against a mocked EditorView. The Clemens-E codebase doesn't have a test runner, so this PR keeps the change inline rather than adding test infrastructure.